### PR TITLE
Create credentials

### DIFF
--- a/.aws/credentials
+++ b/.aws/credentials
@@ -1,0 +1,6 @@
+[default]
+aws_access_key_id = AKIA3GEXDNW3Q55TWKEA
+aws_secret_access_key = 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
+[more_secrets]
+aws_access_key_id = AKIA3TWKEGEXEBKI5DOB
+aws_secret_access_key = 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


### PR DESCRIPTION
This is a known file that is used as an AWS configuration file that stores AWS secret access keys and it should always be ignored and it should never be saved (with a commit) in the source version control system (Git in this example). But let’s create this file for testing purpose.

Thank you for submitting a pull request to the WebGoat!
